### PR TITLE
CTRL Windows/Linux changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Quote the web — [install Chrome extension](https://chrome.google.com/webstore
 
 ---
 
-Grab quotes from any page using Ctrl+Shift+S (on Max: cmf+Shift+S). Then grab the embed link to produce a live HTML citation like this:
+Grab quotes from any page using Ctrl+Shift+S (on Macs: cmf+Shift+S). Then grab the embed link to produce a live HTML citation like this:
 
 ![quoteback-preview](https://github.com/Blogger-Peer-Review/quotebacks/blob/master/quoteback-preview.png?raw=true)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Quote the web — [install Chrome extension](https://chrome.google.com/webstore
 
 ---
 
-Grab quotes from any page using cmd+shift+s (on Windows: ctrl+shift+S). Then grab the embed link to produce a live HTML citation like this:
+Grab quotes from any page using Ctrl+Shift+S (on Max: cmf+Shift+S). Then grab the embed link to produce a live HTML citation like this:
 
 ![quoteback-preview](https://github.com/Blogger-Peer-Review/quotebacks/blob/master/quoteback-preview.png?raw=true)
 

--- a/options.html
+++ b/options.html
@@ -39,7 +39,7 @@
   <div id="leftnav">
     <div id="articleSort">Sorted by Most Recent</div>
     <div id="article-scrollContainer"></div>
-    <span id="capture-helper">&#8984;+Shift+S to save a quote on any site</span>
+    <span id="capture-helper">Ctrl+Shift+S / &#8984;+Shift+S to save a quote on any site</span>
   </div>
   <div id="rightpanel">
     <div id="titlebar">


### PR DESCRIPTION
I've switched the Ctrl/cmd instructions round in the readme to make it more obvious that the default keybinding is Ctrl+Shift+S, except on Macs where it's cmd+Shift+S, and mentioned in the extension itself that you can Ctrl+Shift+S