### PR TITLE
Support for running as Safari extension

### DIFF
--- a/options.html
+++ b/options.html
@@ -39,7 +39,7 @@
   <div id="leftnav">
     <div id="articleSort">Sorted by Most Recent</div>
     <div id="article-scrollContainer"></div>
-    <span id="capture-helper">&#8984;+Shift+S to save a quote on any site</span>
+    <span id="capture-helper"><span id="capture-shortcut">&#8984;+Shift+S</span> to save a quote on any site</span>
   </div>
   <div id="rightpanel">
     <div id="titlebar">

--- a/options.js
+++ b/options.js
@@ -703,6 +703,10 @@ document.addEventListener("DOMContentLoaded", function(){
     globalOptions.addEventListener("mouseout", removeMenu);
 });
 
+document.addEventListener("DOMContentLoaded", function(){
+  var isChrome = navigator.appVersion.indexOf("Chrome/") >= 0;
+  $("#capture-shortcut").text(isChrome ? "&#8984;+Shift+S" : "Shift+S");
+});
 
 
 


### PR DESCRIPTION
Hi folks,

I've spent some some time turning this into a Safari extension and put up the code over here: https://github.com/stigi/quotebacks-safari

An unsigned build can be found under [the releases tab](https://github.com/stigi/quotebacks-safari/releases/tag/1.1.3).

I used the Xcode extension converter and then cleaned up the generated project structure a bit (individual steps can be followed in the commit history of mentioned repo).
I had to fix one issue though which was that the callback when probing for the content scripts to be loaded (via sending a `"ping"` message) never fired. I added a timeout which serves the same purpose in a slightly more hacky way.


I'm attaching some screenshots to show the new extension in action. As a bonus I've added logic to dynamically show the correct shortcut (`alt+s` vs `ctrl+shift+s`) for different browsers.

![CleanShot 2024-03-17 at 08 18 40@2x](https://github.com/Blogger-Peer-Review/quotebacks/assets/13815/257f5732-4bba-49e0-8724-feecac145e2b)
![CleanShot 2024-03-17 at 08 19 28@2x](https://github.com/Blogger-Peer-Review/quotebacks/assets/13815/cb1e7d34-290a-4406-a2fd-6bd42c92ee4b)
![CleanShot 2024-03-17 at 08 20 01@2x](https://github.com/Blogger-Peer-Review/quotebacks/assets/13815/faa4beb0-5d88-4397-8496-e6af7f200ac9)
![CleanShot 2024-03-17 at 08 22 06@2x](https://github.com/Blogger-Peer-Review/quotebacks/assets/13815/80fa3ca6-861c-430f-adeb-4f255aa2fc91)


## What's next?

I'm thinking about releasing it to the AppStore and could do so under my paid developer account, if you folks are cool with that. Alternatively I could explore making the extension available as a signed app as a GitHub release.
Or you could release it under another App Store account.

I'm also very open for moving the code into this repo, or another repo in this org.